### PR TITLE
fix(SE-60): Resolve Auto Rate Setting Issue

### DIFF
--- a/src/main/java/com/finalproject/stayease/property/service/impl/PropertyRateSettingsServiceImpl.java
+++ b/src/main/java/com/finalproject/stayease/property/service/impl/PropertyRateSettingsServiceImpl.java
@@ -190,8 +190,8 @@ public class PropertyRateSettingsServiceImpl implements PropertyRateSettingsServ
       LocalDate endDate, Map<LocalDate, List<PeakSeasonRate>> existingAutoRatesMap) {
     Long propertyId = setting.getProperty().getId();
     for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
-      if (existingAutoRatesMap.containsKey(date)) {
-        // else remove existing auto rates (cases where holiday or long weekend is removed)
+      // If the date is neither a holiday nor a long weekend, deactivate rates
+      if (!holidayService.isHoliday(date) && !holidayService.isLongWeekend(date) && existingAutoRatesMap.containsKey(date)) {
         log.info("Not a holiday or long weekend, removing existing auto rates for property ID: {} on date: {}",
             propertyId, date);
         handleDeactivation(existingAutoRatesMap.get(date));


### PR DESCRIPTION
## PR Summary:
This PR resolves an issue in the auto rate management feature where editing an auto rate would incorrectly deactivate it. Now, auto rates remain active after being edited, ensuring they continue to apply as expected.

This fix improves the accuracy and reliability of the auto rate functionality, preventing unnecessary deactivation during updates.